### PR TITLE
Fix suspension upgrade price check

### DIFF
--- a/Assets/2D_Racing_2/Scripts/Menu/Upgrade.cs
+++ b/Assets/2D_Racing_2/Scripts/Menu/Upgrade.cs
@@ -136,8 +136,8 @@ namespace ALIyerEdon
 					PlayerPrefs.SetInt("Suspension" + id.ToString(), PlayerPrefs.GetInt("Suspension" + id.ToString()) + 1);
 					CoinsTXT.text = PlayerPrefs.GetInt("Coins").ToString();
 					SuspensionTXT.text = "Level : " + PlayerPrefs.GetInt("Suspension" + id.ToString()).ToString() + " / " + suspensionPrice.Length.ToString();
-					if (PlayerPrefs.GetInt("Suspension" + id.ToString()) < speedPrice.Length)
-						priceSuspensionTXT.text = suspensionPrice[PlayerPrefs.GetInt("Suspension" + id.ToString())].ToString() + " $";
+                                        if (PlayerPrefs.GetInt("Suspension" + id.ToString()) < suspensionPrice.Length)
+                                                priceSuspensionTXT.text = suspensionPrice[PlayerPrefs.GetInt("Suspension" + id.ToString())].ToString() + " $";
 					else
 						priceSuspensionTXT.text = "Completed";
 				}


### PR DESCRIPTION
## Summary
- ensure SuspensionUpgrade checks suspensionPrice length
- update label when upgrading suspension levels

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684209e291888320a24023b1763661f7