### PR TITLE
Fix missing reference for Upgrade tests

### DIFF
--- a/Assets/Tests/EditMode/EditModeTests.asmdef
+++ b/Assets/Tests/EditMode/EditModeTests.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "EditModeTests",
     "references": [
-        "UnityEngine.UI"
+        "UnityEngine.UI",
+        "Assembly-CSharp"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"


### PR DESCRIPTION
## Summary
- add `Assembly-CSharp` reference in `EditModeTests.asmdef` so edit mode tests can access game scripts

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68420d0e253c832098b4320ef124c2c1